### PR TITLE
Fix missing coordinates on imported graphs

### DIFF
--- a/src/graph/GraphStore.ts
+++ b/src/graph/GraphStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import Graph from 'graphology';
 import { nanoid } from 'nanoid';
 import { importFromJSON, exportToJSON, createEmptyGraph } from './graphHelpers';
@@ -59,7 +59,15 @@ export const useGraphStore = create<GraphStore>((set, get) => {
     layout: null,
     filters: { nodeTypes: [] },
     loadGraphFromJSON(json) {
-      set({ graph: importFromJSON(json), selection: { nodes: [], edges: [] } });
+      const graph = importFromJSON(json);
+      const needsLayout = graph.nodes().some(key => {
+        const attrs = graph.getNodeAttributes(key);
+        return typeof attrs.x !== 'number' || typeof attrs.y !== 'number';
+      });
+      if (needsLayout) {
+        applyCircular(graph);
+      }
+      set({ graph, selection: { nodes: [], edges: [] } });
     },
     exportGraphJSON() {
       return exportToJSON(get().graph);


### PR DESCRIPTION
## Summary
- Use named `create` import from Zustand
- Apply a circular layout when loading graphs that lack coordinates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c39a33488327b4d48dd4b14228fe