### PR TITLE
Handle custom node types in Sigma

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import Sigma from 'sigma';
+import { NodeCircleProgram } from 'sigma/rendering';
 import { useGraphStore } from '../graph/GraphStore';
 import { nodeColor, nodeSize, edgeColor, edgeSize } from '../graph/styling';
 import { sanitizeNodeAttributes, sanitizeEdgeAttributes } from '../graph/sigmaUtils';
@@ -13,7 +14,24 @@ export default function Canvas() {
 
   useEffect(() => {
     if (!containerRef.current) return;
-    const renderer = new Sigma(graph, containerRef.current);
+
+    const nodeProgramClasses = {
+      Person: NodeCircleProgram,
+      Project: NodeCircleProgram,
+      Team: NodeCircleProgram,
+      default: NodeCircleProgram,
+    } as const;
+
+    graph.forEachNode((key, attrs) => {
+      if (!nodeProgramClasses[attrs.type as keyof typeof nodeProgramClasses]) {
+        graph.setNodeAttribute(key, 'type', 'default');
+      }
+    });
+
+    const renderer = new Sigma(graph, containerRef.current, {
+      nodeProgramClasses,
+      defaultNodeType: 'default',
+    });
 
     renderer.on('clickNode', e => {
       selectNodes([e.node]);


### PR DESCRIPTION
## Summary
- map Person, Project, and Team node types to Sigma's circle program
- fallback to a default node program when encountering unknown node types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c9aa346c832794afe8bc90328949