### PR TITLE
Handle custom edge types in Sigma renderer

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import Sigma from 'sigma';
-import { NodeCircleProgram } from 'sigma/rendering';
+import { NodeCircleProgram, EdgeLineProgram } from 'sigma/rendering';
 import { useGraphStore } from '../graph/GraphStore';
 import { nodeColor, nodeSize, edgeColor, edgeSize } from '../graph/styling';
 import { sanitizeNodeAttributes, sanitizeEdgeAttributes } from '../graph/sigmaUtils';
@@ -22,15 +22,32 @@ export default function Canvas() {
       default: NodeCircleProgram,
     } as const;
 
+    const edgeProgramClasses = {
+      REPORTS_TO: EdgeLineProgram,
+      MANAGES: EdgeLineProgram,
+      WORKS_ON: EdgeLineProgram,
+      KNOWS: EdgeLineProgram,
+      BELONGS_TO: EdgeLineProgram,
+      default: EdgeLineProgram,
+    } as const;
+
     graph.forEachNode((key, attrs) => {
       if (!nodeProgramClasses[attrs.type as keyof typeof nodeProgramClasses]) {
         graph.setNodeAttribute(key, 'type', 'default');
       }
     });
 
+    graph.forEachEdge((key, attrs) => {
+      if (!edgeProgramClasses[attrs.type as keyof typeof edgeProgramClasses]) {
+        graph.setEdgeAttribute(key, 'type', 'default');
+      }
+    });
+
     const renderer = new Sigma(graph, containerRef.current, {
       nodeProgramClasses,
+      edgeProgramClasses,
       defaultNodeType: 'default',
+      defaultEdgeType: 'default',
     });
 
     renderer.on('clickNode', e => {


### PR DESCRIPTION
## Summary
- Map domain-specific edge types to Sigma edge programs and set default edge type
- Normalize unknown edge types before rendering to avoid runtime errors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4cae9be508327b886f6e706f78e1f