### PR TITLE
Add error boundary and guard against invalid graph JSON

### DIFF
--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default class ErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  constructor(props: any) {
+    super(props);
+    this.state = { error: null };
+  }
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="p-4">
+          <h2 className="text-lg font-semibold">Something went wrong</h2>
+          <pre className="mt-2 text-sm whitespace-pre-wrap">{String(this.state.error)}</pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -57,8 +57,9 @@ export default function Canvas() {
       selectEdges([e.edge]);
     });
 
+    const nodeTypes = Array.isArray(filters?.nodeTypes) ? filters.nodeTypes : [];
     renderer.setSetting('nodeReducer', (node, data) => {
-      if (filters.nodeTypes.length && !filters.nodeTypes.includes(String(data.type))) {
+      if (nodeTypes.length && !nodeTypes.includes(String(data.type))) {
         return { hidden: true };
       }
       return {

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { useGraphStore } from '../graph/GraphStore';
 import { openFile, saveFile } from '../graph/persistence';
+import { normalizeGraphJSON } from '../graph/normalize';
 import AddNodeModal from './Modals/AddNodeModal';
 import AddEdgeModal from './Modals/AddEdgeModal';
 import ConfirmDeleteModal from './Modals/ConfirmDeleteModal';
-import { GraphologyJSON } from '../types/graph';
 
 export default function TopBar() {
   const loadGraphFromJSON = useGraphStore(s => s.loadGraphFromJSON);
@@ -25,7 +25,8 @@ export default function TopBar() {
 
   async function handleOpen() {
     const json = await openFile();
-    if (json) loadGraphFromJSON(json as GraphologyJSON);
+    const normalized = normalizeGraphJSON(json);
+    if (normalized) loadGraphFromJSON(normalized);
   }
 
   async function handleSave() {

--- a/src/graph/normalize.ts
+++ b/src/graph/normalize.ts
@@ -1,0 +1,29 @@
+import { GraphologyJSON } from '../types/graph';
+
+export function normalizeGraphJSON(data: any): GraphologyJSON | null {
+  if (!data || typeof data !== 'object') return null;
+  const attributes = typeof data.attributes === 'object' && data.attributes !== null ? data.attributes : {};
+  const options = typeof data.options === 'object' && data.options !== null ? data.options : {};
+  const nodes = Array.isArray(data.nodes) ? data.nodes : [];
+  const edges = Array.isArray(data.edges) ? data.edges : [];
+
+  return {
+    attributes,
+    options,
+    nodes: nodes
+      .filter((n: any) => n && n.key)
+      .map((n: any) => ({
+        key: String(n.key),
+        attributes: typeof n.attributes === 'object' && n.attributes !== null ? n.attributes : {},
+      })),
+    edges: edges
+      .filter((e: any) => e && e.source && e.target)
+      .map((e: any) => ({
+        key: e.key ? String(e.key) : undefined,
+        source: String(e.source),
+        target: String(e.target),
+        attributes: typeof e.attributes === 'object' && e.attributes !== null ? e.attributes : {},
+        undirected: Boolean(e.undirected),
+      })),
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import LeftPanel from './components/LeftPanel';
 import RightPanel from './components/RightPanel';
 import Canvas from './components/Canvas';
 import './app.css';
+import ErrorBoundary from './ErrorBoundary';
 
 function App() {
   return (
@@ -23,6 +24,8 @@ function App() {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- wrap app with an error boundary to prevent blank screens
- normalize imported graph JSON to avoid undefined filters
- guard sigma node reducer against missing filter values

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4cf370b00832788803eddd6086620