### PR TITLE
feat: portal modal frame

### DIFF
--- a/src/components/Modals/AddEdgeModal.tsx
+++ b/src/components/Modals/AddEdgeModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useGraphStore } from '../../graph/GraphStore';
+import ModalFrame from './ModalFrame';
 
 export default function AddEdgeModal({ onClose }: { onClose: () => void }) {
   const addEdge = useGraphStore(s => s.addEdge);
@@ -17,8 +18,8 @@ export default function AddEdgeModal({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <form onSubmit={handleSubmit} className="bg-white p-4 space-y-2">
+    <ModalFrame>
+      <form onSubmit={handleSubmit} className="space-y-2">
         <div>
           <label className="block">Source</label>
           <select className="border px-2" value={source} onChange={e => setSource(e.target.value)}>
@@ -43,6 +44,6 @@ export default function AddEdgeModal({ onClose }: { onClose: () => void }) {
         </div>
         <button type="submit" className="px-2 py-1 border bg-gray-100">Add</button>
       </form>
-    </div>
+    </ModalFrame>
   );
 }

--- a/src/components/Modals/AddNodeModal.tsx
+++ b/src/components/Modals/AddNodeModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useGraphStore } from '../../graph/GraphStore';
+import ModalFrame from './ModalFrame';
 
 export default function AddNodeModal({ onClose }: { onClose: () => void }) {
   const addNode = useGraphStore(s => s.addNode);
@@ -14,8 +15,8 @@ export default function AddNodeModal({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <form onSubmit={handleSubmit} className="bg-white p-4 space-y-2">
+    <ModalFrame>
+      <form onSubmit={handleSubmit} className="space-y-2">
         <div>
           <label className="block">Label</label>
           <input className="border px-2" value={label} onChange={e => setLabel(e.target.value)} />
@@ -26,6 +27,6 @@ export default function AddNodeModal({ onClose }: { onClose: () => void }) {
         </div>
         <button type="submit" className="px-2 py-1 border bg-gray-100">Add</button>
       </form>
-    </div>
+    </ModalFrame>
   );
 }

--- a/src/components/Modals/ConfirmDeleteModal.tsx
+++ b/src/components/Modals/ConfirmDeleteModal.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
+import ModalFrame from './ModalFrame';
 
 export default function ConfirmDeleteModal({ onConfirm, onClose }: { onConfirm: () => void; onClose: () => void }) {
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <div className="bg-white p-4">
-        <p>Delete selected items?</p>
-        <div className="mt-2 flex gap-2">
-          <button onClick={onConfirm} className="px-2 py-1 border bg-red-100">Delete</button>
-          <button onClick={onClose} className="px-2 py-1 border bg-gray-100">Cancel</button>
-        </div>
+    <ModalFrame>
+      <p>Delete selected items?</p>
+      <div className="mt-2 flex gap-2">
+        <button onClick={onConfirm} className="px-2 py-1 border bg-red-100">Delete</button>
+        <button onClick={onClose} className="px-2 py-1 border bg-gray-100">Cancel</button>
       </div>
-    </div>
+    </ModalFrame>
   );
 }

--- a/src/components/Modals/ModalFrame.tsx
+++ b/src/components/Modals/ModalFrame.tsx
@@ -1,0 +1,12 @@
+import { createPortal } from "react-dom";
+
+export default function ModalFrame({ children }: { children: React.ReactNode }) {
+  return createPortal(
+    <div className="fixed inset-0 z-[9999] bg-black/50 flex items-center justify-center" role="dialog" aria-modal="true">
+      <div className="bg-white rounded-lg shadow-xl p-4 pointer-events-auto" onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `ModalFrame` component using a React portal and high z-index
- wrap node, edge, and delete modals in `ModalFrame`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4427d2c8327a8e9b618c4e3d1cf