### PR TITLE
Enable selection clearing via stage clicks

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -50,11 +50,17 @@ export default function Canvas() {
       defaultEdgeType: 'default',
     });
 
-    renderer.on('clickNode', e => {
-      selectNodes([e.node]);
+    renderer.on('clickNode', ({ node }) => {
+      selectEdges([]);
+      selectNodes([node]);
     });
-    renderer.on('clickEdge', e => {
-      selectEdges([e.edge]);
+    renderer.on('clickEdge', ({ edge }) => {
+      selectNodes([]);
+      selectEdges([edge]);
+    });
+    renderer.on('clickStage', () => {
+      selectNodes([]);
+      selectEdges([]);
     });
 
     renderer.setSetting("nodeReducer", (node, data) => {


### PR DESCRIPTION
## Summary
- clear node and edge selections when clicking the background
- ensure node and edge clicks select only their respective items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d8dffd8483278f77f66f740b8e26