### PR TITLE
feat: add dynamic filters

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -1,0 +1,15 @@
+# Dynamic Filters
+
+The Filters panel discovers facets directly from the data on the graph. Keys are
+scanned from the nodes and matched against a whitelist of candidates defined in
+`src/filters/facetConfig.ts`. A facet is shown only when it appears on at least
+5% of sampled nodes and has at least two distinct values.
+
+Each option displays two counts:
+- `countAll`: how many nodes on the canvas have that value.
+- `countWithOtherFilters`: how many nodes would remain if this value were
+  toggled while preserving other active filters.
+
+To add or remove candidate keys, edit the arrays in
+`src/filters/facetConfig.ts`. Array-valued fields such as `tags` are split into
+individual values.

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useFiltersStore } from '../state/filtersStore';
+
+export default function Filters() {
+  const availableFacets = useFiltersStore(s => s.availableFacets);
+  const selected = useFiltersStore(s => s.selected);
+  const toggleValue = useFiltersStore(s => s.toggleValue);
+  const clearGroup = useFiltersStore(s => s.clearGroup);
+  const clearAll = useFiltersStore(s => s.clearAll);
+  const setSelected = useFiltersStore(s => s.setSelected);
+  const search = useFiltersStore(s => s.search);
+  const setSearch = useFiltersStore(s => s.setSearch);
+
+  return (
+    <div className="w-48 p-2 border-r overflow-auto text-sm">
+      <h3 className="font-bold mb-2">Filters</h3>
+      <input
+        className="border p-1 w-full mb-2"
+        placeholder="Search..."
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+      {availableFacets.map(f => {
+        return (
+          <div key={f.key} className="mb-2">
+            <div className="flex justify-between items-center mb-1">
+              <span className="font-semibold capitalize">{f.key}</span>
+              <div className="space-x-1">
+                <button
+                  className="text-xs text-blue-600"
+                  onClick={() =>
+                    setSelected(f.key, f.values.map(v => v.value))
+                  }
+                >
+                  All
+                </button>
+                <button
+                  className="text-xs text-blue-600"
+                  onClick={() => clearGroup(f.key)}
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+            {f.values.map(opt => (
+              <label key={opt.value} className="block">
+                <input
+                  type="checkbox"
+                  className="mr-1"
+                  checked={!!selected[f.key]?.has(opt.value)}
+                  onChange={() => toggleValue(f.key, opt.value)}
+                />
+                {opt.value} ({opt.countWithOtherFilters})
+              </label>
+            ))}
+          </div>
+        );
+      })}
+      {availableFacets.length > 0 && (
+        <button className="mt-2 text-sm text-blue-600" onClick={clearAll}>
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -1,45 +1,6 @@
 import React from 'react';
-import { useGraphStore } from '../graph/GraphStore';
+import Filters from './Filters';
 
 export default function LeftPanel() {
-  const graph = useGraphStore(s => s.graph);
-  const filters = useGraphStore(s => s.filters);
-  const applyFilters = useGraphStore(s => s.applyFilters);
-  const clearFilters = useGraphStore(s => s.clearFilters);
-
-  const nodeTypes = React.useMemo(
-    () =>
-      Array.from(
-        new Set(
-          graph
-            .nodes()
-            .map(n => graph.getNodeAttribute(n, 'type'))
-            .filter(Boolean)
-        )
-      ),
-    [graph]
-  );
-
-  function toggle(type: string) {
-    const newTypes = filters.nodeTypes.includes(type)
-      ? filters.nodeTypes.filter(t => t !== type)
-      : [...filters.nodeTypes, type];
-
-    if (newTypes.length === 0) clearFilters();
-    else applyFilters({ nodeTypes: newTypes });
-  }
-
-  return (
-    <div className="w-40 p-2 border-r overflow-auto">
-      <h3 className="font-bold mb-2">Filters</h3>
-      {nodeTypes.map(t => (
-        <label key={t} className="block">
-          <input type="checkbox" checked={filters.nodeTypes.includes(t)} onChange={() => toggle(t)} /> {t}
-        </label>
-      ))}
-      {filters.nodeTypes.length > 0 && (
-        <button onClick={clearFilters} className="mt-2 text-sm text-blue-600">Clear</button>
-      )}
-    </div>
-  );
+  return <Filters />;
 }

--- a/src/filters/facetConfig.ts
+++ b/src/filters/facetConfig.ts
@@ -1,0 +1,10 @@
+export const NODE_FACET_CANDIDATES = [
+  "kind", "type", "status", "team", "owner", "domain", "category", "tags"
+] as const;
+
+export const EDGE_FACET_CANDIDATES = [
+  "relationship_type"
+] as const;
+
+export const IGNORE_KEYS = ["x", "y", "size", "color", "label", "hidden", "key", "id"];
+

--- a/src/filters/indexer.ts
+++ b/src/filters/indexer.ts
@@ -1,0 +1,79 @@
+import type Graph from "graphology";
+import { IGNORE_KEYS, NODE_FACET_CANDIDATES } from "./facetConfig";
+
+export interface FacetOption {
+  value: string;
+  countAll: number;
+  countWithOtherFilters: number;
+}
+
+export interface FacetGroup {
+  key: string;
+  values: FacetOption[];
+}
+
+export function buildFacetIndex(
+  graph: Graph,
+  facetKeys: string[],
+  predicateBuilder: (exclude?: string) => (attrs: any) => boolean
+): FacetGroup[] {
+  const facets: FacetGroup[] = [];
+  const nodes = graph.nodes();
+
+  for (const key of facetKeys) {
+    const countsAll = new Map<string, number>();
+    const countsWith = new Map<string, number>();
+    const predicate = predicateBuilder(key);
+
+    for (const n of nodes) {
+      const attrs = graph.getNodeAttributes(n);
+      let values: string[] = [];
+      const v = (attrs as any)[key];
+      if (Array.isArray(v)) values = v.map(x => String(x));
+      else if (v !== undefined && v !== null) values = [String(v)];
+      if (!values.length) continue;
+
+      for (const val of values) {
+        countsAll.set(val, (countsAll.get(val) || 0) + 1);
+        if (predicate(attrs)) {
+          countsWith.set(val, (countsWith.get(val) || 0) + 1);
+        }
+      }
+    }
+
+    const values = Array.from(countsAll.keys()).map(value => ({
+      value,
+      countAll: countsAll.get(value) || 0,
+      countWithOtherFilters: countsWith.get(value) || 0,
+    }));
+
+    facets.push({ key, values });
+  }
+
+  return facets;
+}
+
+export function discoverNodeFacetKeys(graph: Graph, sampleLimit = 1000): string[] {
+  const nodes = graph.nodes().slice(0, sampleLimit);
+  const distincts: Record<string, Set<string>> = {};
+  const counts: Record<string, number> = {};
+
+  for (const n of nodes) {
+    const attrs = graph.getNodeAttributes(n) as Record<string, any>;
+    for (const [k, v] of Object.entries(attrs)) {
+      if (IGNORE_KEYS.includes(k)) continue;
+      if (v === undefined || v === null) continue;
+      counts[k] = (counts[k] || 0) + 1;
+      const set = (distincts[k] ||= new Set<string>());
+      if (Array.isArray(v)) v.forEach(x => set.add(String(x)));
+      else set.add(String(v));
+    }
+  }
+
+  const threshold = nodes.length * 0.05;
+  const discovered = Object.entries(distincts)
+    .filter(([k, set]) => set.size >= 2 && counts[k] >= threshold)
+    .map(([k]) => k);
+  return discovered.filter(k => (NODE_FACET_CANDIDATES as readonly string[]).includes(k));
+}
+

--- a/src/filters/sync.ts
+++ b/src/filters/sync.ts
@@ -1,0 +1,47 @@
+import type Graph from "graphology";
+import { debounce } from "../util/debounce";
+import { discoverNodeFacetKeys, buildFacetIndex } from "./indexer";
+import { useFiltersStore, makeNodePredicate } from "../state/filtersStore";
+import shallow from "zustand/shallow";
+
+export function syncFiltersFromGraph(graph: Graph) {
+  const keys = discoverNodeFacetKeys(graph);
+  const { selected, search, setAvailableFacets } = useFiltersStore.getState();
+
+  const predicateBuilder = (exclude?: string) => {
+    const sel = { ...selected };
+    if (exclude) delete sel[exclude];
+    return makeNodePredicate(sel, search);
+  };
+
+  const facets = buildFacetIndex(graph, keys, predicateBuilder);
+  setAvailableFacets(facets);
+}
+
+export function attachGraphListenersForFilters(graph: Graph) {
+  const debouncedSync = debounce(() => syncFiltersFromGraph(graph), 100);
+  const events = [
+    "nodeAdded",
+    "nodeDropped",
+    "nodeAttributesUpdated",
+    "edgeAdded",
+    "edgeDropped",
+    "edgeAttributesUpdated",
+  ];
+
+  events.forEach(ev => graph.on(ev, debouncedSync));
+
+  const unsubscribe = useFiltersStore.subscribe(
+    s => [s.selected, s.search],
+    debouncedSync,
+    { equalityFn: shallow }
+  );
+
+  debouncedSync();
+
+  return () => {
+    events.forEach(ev => graph.off(ev, debouncedSync));
+    unsubscribe();
+  };
+}
+

--- a/src/graph/reducers.ts
+++ b/src/graph/reducers.ts
@@ -1,5 +1,6 @@
 import { KIND_THEME } from './theme';
 import type { NodeReducer } from 'sigma/types';
+import { useFiltersStore, makeNodePredicate } from '../state/filtersStore';
 
 export const nodeReducer: NodeReducer = (id, attrs) => {
   const kind = (attrs as any).kind || 'default';
@@ -12,11 +13,16 @@ export const nodeReducer: NodeReducer = (id, attrs) => {
     type = kind === 'asset' ? 'square' : kind === 'person' ? 'image' : 'circle';
   }
 
-  return {
+  const { selected, search } = useFiltersStore.getState();
+  const visible = makeNodePredicate(selected, search)(attrs);
+
+  const base = {
     ...(attrs as any),
     size,
     color: theme.color,
     headerColor: theme.header,
     type,
   } as any;
+
+  return visible ? base : { ...base, hidden: true };
 };

--- a/src/state/filtersStore.ts
+++ b/src/state/filtersStore.ts
@@ -1,0 +1,66 @@
+import { create } from "zustand";
+
+export type FacetKey = string;
+export type Selection = Record<FacetKey, Set<string>>;
+
+interface FiltersState {
+  availableFacets: { key: FacetKey; values: Array<{ value: string; countAll: number; countWithOtherFilters: number }> }[];
+  selected: Selection;
+  search: string;
+  setSelected: (key: FacetKey, values: string[] | Set<string>) => void;
+  toggleValue: (key: FacetKey, value: string) => void;
+  clearGroup: (key: FacetKey) => void;
+  clearAll: () => void;
+  setAvailableFacets: (facets: FiltersState["availableFacets"]) => void;
+  setSearch: (q: string) => void;
+}
+
+export const useFiltersStore = create<FiltersState>((set) => ({
+  availableFacets: [],
+  selected: {},
+  search: "",
+  setSelected: (key, values) =>
+    set((state) => ({
+      selected: { ...state.selected, [key]: new Set(values as any) },
+    })),
+  toggleValue: (key, value) =>
+    set((state) => {
+      const current = new Set(state.selected[key] || []);
+      if (current.has(value)) current.delete(value);
+      else current.add(value);
+      return { selected: { ...state.selected, [key]: current } };
+    }),
+  clearGroup: (key) =>
+    set((state) => {
+      const next = { ...state.selected };
+      delete next[key];
+      return { selected: next };
+    }),
+  clearAll: () => set({ selected: {} }),
+  setAvailableFacets: (facets) => set({ availableFacets: facets }),
+  setSearch: (q) => set({ search: q }),
+}));
+
+export function makeNodePredicate(selected: Selection, search?: string) {
+  return (attrs: any) => {
+    for (const [facet, values] of Object.entries(selected)) {
+      const set = values as Set<string>;
+      if (!set || set.size === 0) continue;
+      const v = (attrs as any)[facet];
+      if (Array.isArray(v)) {
+        const has = v.some((x) => set.has(String(x)));
+        if (!has) return false;
+      } else if (!set.has(String(v))) {
+        return false;
+      }
+    }
+    if (search && search.trim()) {
+      const s = search.toLowerCase();
+      const label = String((attrs as any).label ?? "").toLowerCase();
+      const key = String((attrs as any).key ?? "").toLowerCase();
+      if (!label.includes(s) && !key.includes(s)) return false;
+    }
+    return true;
+  };
+}
+

--- a/src/util/debounce.ts
+++ b/src/util/debounce.ts
@@ -1,0 +1,7 @@
+export function debounce<T extends (...args: any[]) => void>(fn: T, wait: number) {
+  let t: any;
+  return (...args: Parameters<T>) => {
+    clearTimeout(t);
+    t = setTimeout(() => fn(...args), wait);
+  };
+}


### PR DESCRIPTION
## Summary
- index graph data to auto-generate facet groups and option counts
- add zustand filter store and predicate applied in node reducer
- sync filters to graph updates and render dynamic filter UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8988777fc8327be929b008a0eaf6f