### PR TITLE
Resolve avatar image scheme to avoid CORS errors

### DIFF
--- a/src/graph/normalize.ts
+++ b/src/graph/normalize.ts
@@ -33,5 +33,16 @@ export function normalizeNode(n: any): GraphNodeAttrs {
 
   out.ui = out.ui || {};
 
+  // Resolve custom avatar image scheme to a concrete, fetchable URL.  The
+  // sample graph uses values such as `avatar:eli` for the `image` attribute.
+  // Browsers treat the `avatar:` protocol as an invalid scheme and block the
+  // request, resulting in CORS errors.  To make these images load properly we
+  // transform any `avatar:NAME` value into a DiceBear avatar URL which is
+  // served with permissive CORS headers.
+  if (typeof out.image === "string" && out.image.startsWith("avatar:")) {
+    const seed = encodeURIComponent(out.image.slice("avatar:".length));
+    out.image = `https://api.dicebear.com/6.x/thumbs/png?seed=${seed}`;
+  }
+
   return out as GraphNodeAttrs;
 }

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { useGraphStore } from '../src/graph/GraphStore';
 import sample from '../public/data/sample-graph.json';
 import { sanitizeNodeAttributes } from '../src/graph/sigmaUtils';
+import { normalizeNode } from '../src/graph/normalize';
 
 describe('Sample graph loading', () => {
   it('loads sample graph', async () => {
@@ -17,5 +18,12 @@ describe('Sigma attribute sanitization', () => {
     const input = { label: 'Alice', kind: 'person', shape: 'circle', x: 1, y: 2, size: 20 };
     const result = sanitizeNodeAttributes(input);
     expect(result).toEqual(input);
+  });
+});
+
+describe('Avatar image resolution', () => {
+  it('converts avatar: scheme to an HTTP URL', () => {
+    const result = normalizeNode({ key: 'n1', image: 'avatar:eli' });
+    expect(result.image).toBe('https://api.dicebear.com/6.x/thumbs/png?seed=eli');
   });
 });


### PR DESCRIPTION
## Summary
- Convert `avatar:` image URLs into DiceBear HTTP URLs during node normalization to prevent CORS failures
- Test avatar scheme conversion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c4ed90f08327b41c396528a03cfe